### PR TITLE
Allow custom registry base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ from ui.dialogs import ProjectBrowserDialog
 # dialog = ProjectBrowserDialog(registry, parent)
 ```
 
+### 注册表 CSV 导出
+
+`utils/convert_registry_to_csv.py` 提供 `watch_and_convert()` 函数，可以在
+`project_registry.json` 更新时自动生成 `project_registry.csv`。调用时可选地
+传入 `base_path` 参数指定注册表目录，默认为脚本所在目录。
+
+```python
+from pathlib import Path
+from cx_project_manager.utils.convert_registry_to_csv import watch_and_convert
+
+# 自定义注册表路径
+watch_and_convert(Path("E:/3_Projects/_proj_settings"))
+```
+
 ## ⚠️ 注意事项
 
 1. **保持依赖**: `_utils/` 文件夹中的文件保持原样，确保样式和版本信息正常工作

--- a/cx_project_manager/utils/convert_registry_to_csv.py
+++ b/cx_project_manager/utils/convert_registry_to_csv.py
@@ -51,10 +51,20 @@ def convert_registry_to_csv(project_base: Optional[Path] = None) -> bool:
         return False
 
 
-def watch_and_convert():
-    """监视JSON文件变化并自动转换"""
-    json_path = Path("E:/3_Projects/_proj_settings/project_registry.json")
-    csv_path = Path("E:/3_Projects/_proj_settings/project_registry.csv")
+def watch_and_convert(base_path: Optional[Path] = None):
+    """监视JSON文件变化并自动转换
+
+    Parameters
+    ----------
+    base_path : Path, optional
+        项目注册表所在目录，默认为当前脚本所在目录。
+    """
+
+    if base_path is None:
+        base_path = Path(__file__).resolve().parent
+
+    json_path = Path(base_path) / "project_registry.json"
+    csv_path = Path(base_path) / "project_registry.csv"
 
     # 获取JSON文件的修改时间
     if not json_path.exists():
@@ -71,7 +81,7 @@ def watch_and_convert():
             return
 
     # 执行转换
-    convert_registry_to_csv()
+    convert_registry_to_csv(base_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `watch_and_convert()` accept an optional `base_path`
- update documentation with example usage

## Testing
- `python -m compileall -q cx_project_manager`

------
https://chatgpt.com/codex/tasks/task_e_6887657afe0083258804c7bb0b80c52a